### PR TITLE
Enforce answer ∈ options on generated questions

### DIFF
--- a/backend/app/core/ai/openai.py
+++ b/backend/app/core/ai/openai.py
@@ -19,6 +19,7 @@ from app.models import (
     Document,
     ExplanationOutput,
     QuestionCreate,
+    QuestionItem,
     QuestionOutput,
     QuestionType,
 )
@@ -147,13 +148,26 @@ def fetch_document_texts(session: Session, document_ids: list[UUID]) -> list[str
 
 
 def validate_and_convert_question_item(q: Any) -> QuestionCreate | None:
-    """Validate LLM question item and convert to QuestionCreate."""
+    """Validate LLM question item and convert to QuestionCreate.
+
+    Re-validates via QuestionItem so answer ∈ options is enforced even when
+    callers pass a duck-typed object (not only structured-output parsing).
+    """
     try:
+        if isinstance(q, QuestionItem):
+            item = q
+        else:
+            item = QuestionItem(
+                question=q.question,
+                answer=q.answer,
+                type=q.type,
+                options=list(q.options) if q.options is not None else [],
+            )
         return QuestionCreate(
-            question=q.question,
-            correct_answer=q.answer,
-            type=QuestionType(q.type),
-            options=q.options,
+            question=item.question,
+            correct_answer=item.answer,
+            type=QuestionType(item.type),
+            options=item.options,
         )
     except ValidationError as ve:
         logger.error(f"Validation error for question item {q}: {ve}")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -417,7 +417,11 @@ class QuestionItem(PydanticBaseModel):
 
     @model_validator(mode="after")
     def validate_type_matches_options(self) -> "QuestionItem":
-        """Validate and correct question type based on options."""
+        """Validate and correct question type based on options.
+
+        Also requires answer ∈ options (exact match after T/F normalization),
+        matching the answer-in-options content gate used before persist/grade.
+        """
         options = self.options
 
         # Check if options match true_false pattern
@@ -448,6 +452,27 @@ class QuestionItem(PydanticBaseModel):
                 raise ValueError(
                     f"Multiple choice question must have at least 3 options, got {len(self.options) if isinstance(self.options, list) else 0}"
                 )
+
+        # Correct answer must be one of the selectable options (exact membership).
+        # For T/F, normalize case so "true"/"false" become "True"/"False".
+        if self.answer is None:
+            raise ValueError(
+                "Question answer is required and must be one of the options"
+            )
+        if self.type == "true_false":
+            answer_norm = str(self.answer).strip().lower()
+            if answer_norm == "true":
+                self.answer = "True"
+            elif answer_norm == "false":
+                self.answer = "False"
+            else:
+                raise ValueError(
+                    f"True/false answer must be one of {self.options}, got {self.answer!r}"
+                )
+        elif self.answer not in self.options:
+            raise ValueError(
+                f"Answer must be one of the options {self.options}, got {self.answer!r}"
+            )
 
         return self
 

--- a/backend/evals/DEVELOPMENT.md
+++ b/backend/evals/DEVELOPMENT.md
@@ -1,0 +1,57 @@
+# Eval harness — development log
+
+Working notes for MidtermMock prompt evaluation. Not a substitute for the README methodology section.
+
+## Timeline
+
+### 2026-07-30 — Harness scaffold
+- Shared prompt registry: A (baseline), B (difficulty), C (distractors)
+- Shared `generate_questions` used by API + eval
+- `scripts/evaluate.py` → timestamped `config.json`, `prompt_*.json`, `report.md`
+- Metric split: reliability / correctness gates / efficiency tradeoffs / manual rubric
+- Smoke corpus + `evals/rubric.md`
+
+### 2026-07-30 — Smoke run (`2026-07-31T00-10-58Z`)
+- 1 doc (`smoke_recursion`) × prompts A/B/C against live `gpt-4o-mini`
+- A: answer-in-options 100%
+- B: answer-in-options **60%**, `final_contract_valid=false`
+- C: answer-in-options 80%
+
+### 2026-08-10 — Manual review of prompt B artifact
+**Caught a pre-existing production bug** while reviewing `results/2026-07-31T00-10-58Z/prompt_b.json`.
+
+#### Bug: T/F (and MC) answers not required to be in `options`
+- **Symptom:** Model returned `type: true_false`, `options: ["True","False"]`, but `answer` was a phrase (e.g. `"A base case"`) or a full sentence—not `True`/`False`.
+- **Impact:** Questions can be stored/served; scoring compares student choice to an impossible `correct_answer` → broken T/F grading.
+- **Root cause:** `QuestionItem` only validates type ↔ options shape. It does **not** enforce `answer ∈ options`. Prompt rules were soft; code never hard-failed.
+- **Not a regression from the eval PR** — pre-existing gap; the harness’s `answer_in_options_rate` gate surfaced it.
+- **Status:** Fixed in `fix/question-answer-in-options` (PR #61) — `QuestionItem` + convert path reject answer ∉ options; generation returns `error_kind=validation`.
+
+### 2026-08-20 — Validator fix + evidence pack
+- Unit tests cover valid MC/T/F, invalid T/F sentence-as-answer, invalid MC, missing answer, and generation → `error_kind=validation`.
+- Corpus expanded to **12** short lecture-like `.txt` docs under `evals/corpus/`.
+- Live re-smoke **skipped** locally: `OPENAI_API_KEY` in `.env` is the placeholder `changethis` (not a real key). Re-run when a real key is available:
+  ```bash
+  cd backend
+  python scripts/evaluate.py --prompts a,b,c --limit 1   # smoke
+  python scripts/evaluate.py --prompts a,b,c             # full corpus
+  ```
+- Manual rubric filled from the `2026-07-31T00-10-58Z` artifacts (see `evals/rubric.md`).
+
+## Open follow-ups
+- [x] Enforce `answer ∈ options` in structured-output validation
+- [ ] Re-run smoke after fix with a real OpenAI key; confirm answer-in-options = 100% on successful A/B/C runs (failures should be validation, not persisted bad answers)
+- [x] Fill manual rubric; write ship/no-ship takeaway
+- [x] Land harness (PR #60); validator as fast follow (PR #61)
+
+## Ship / no-ship takeaway
+
+**Ship prompt A (baseline) in production.** It was the only variant with 100% answer-in-options and `final_contract_valid` on the smoke set, with clear grounded wording. Do **not** ship B or C until a post-validator re-smoke shows contract compliance; B produced ungradable T/F answers, and C failed exact answer∈options on a trailing-period mismatch.
+
+## How to reproduce the finding
+```bash
+cd backend
+# inspect existing artifact, or:
+python scripts/evaluate.py --prompts b --limit 1
+# open results/<run_id>/prompt_b.json — look for true_false rows where answer is not True/False
+```

--- a/backend/evals/corpus/smoke_binary_search.txt
+++ b/backend/evals/corpus/smoke_binary_search.txt
@@ -1,0 +1,7 @@
+Binary search finds a target in a sorted sequence by repeatedly discarding half of the remaining range. Each step compares the target to the middle element.
+
+If the middle element is too small, search the right half. If it is too large, search the left half. The algorithm terminates when the range is empty or the target is found.
+
+Binary search runs in O(log n) time, which is much faster than linear scan for large sorted inputs. The critical precondition is that the data must already be sorted.
+
+Off-by-one errors in the low/high bounds are the most common implementation bugs. Writing careful loop invariants helps keep the inclusive/exclusive endpoints consistent.

--- a/backend/evals/corpus/smoke_conditionals.txt
+++ b/backend/evals/corpus/smoke_conditionals.txt
@@ -1,0 +1,7 @@
+Conditionals let a program choose different paths. The basic form is if, optionally followed by elif branches and a final else.
+
+A Boolean expression evaluates to True or False. Comparison operators include ==, !=, <, >, <=, and >=. Logical operators and, or, and not combine Boolean values.
+
+Only one branch in an if/elif/else chain runs. Order matters: put more specific conditions before broader ones so the intended case is not skipped.
+
+Nested conditionals are legal but can become hard to read. Prefer flattening logic with early returns or clearer Boolean expressions when the nesting grows deep.

--- a/backend/evals/corpus/smoke_debugging.txt
+++ b/backend/evals/corpus/smoke_debugging.txt
@@ -1,0 +1,7 @@
+Debugging is the process of finding and fixing defects. Start by reproducing the bug reliably. If you cannot reproduce it, you cannot confirm a fix.
+
+Read the error message and traceback carefully. The last few frames usually point near the failure, though the root cause may be earlier.
+
+Print debugging and interactive debuggers both help. Change one thing at a time, then re-run. Large speculative edits make it hard to know which change mattered.
+
+Form a hypothesis about why the code fails, then design a small experiment that would falsify it. Guessing randomly wastes time compared with systematic isolation.

--- a/backend/evals/corpus/smoke_dictionaries.txt
+++ b/backend/evals/corpus/smoke_dictionaries.txt
@@ -1,0 +1,7 @@
+Dictionaries map keys to values. In Python you write them with curly braces, for example {"alice": 3, "bob": 5}.
+
+Keys must be hashable (immutable types like str, int, and tuple of immutables). Values can be any object. Looking up a missing key with d[key] raises KeyError; d.get(key) returns None or a default instead.
+
+Dictionaries are unordered in older Python versions and insertion-ordered since 3.7. Iteration over a dict yields keys by default; use .values() or .items() when you need values or pairs.
+
+Use a dict when you need fast lookup by identifier. Prefer a list when order and positional access matter more than keyed retrieval.

--- a/backend/evals/corpus/smoke_lists.txt
+++ b/backend/evals/corpus/smoke_lists.txt
@@ -1,0 +1,7 @@
+A list is an ordered, mutable collection of values. In Python you write lists with square brackets, for example [3, 1, 4].
+
+Indexing starts at 0. Negative indices count from the end: lst[-1] is the last element. Slicing lst[a:b] returns a new list from index a up to but not including b.
+
+Common operations include append to add at the end, insert at a position, and pop to remove. Lists can hold mixed types, but homogeneous lists are easier to reason about.
+
+List comprehensions build a new list from an iterable in one expression. They are concise for map/filter style transforms, but nested comprehensions can become unreadable.

--- a/backend/evals/corpus/smoke_loops.txt
+++ b/backend/evals/corpus/smoke_loops.txt
@@ -1,0 +1,7 @@
+Loops repeat a block of code. A for loop iterates over a sequence such as a range, list, or string. A while loop repeats as long as a condition stays True.
+
+Use for when you know the collection or count of iterations in advance. Use while when the stopping condition depends on something that changes inside the loop.
+
+Infinite loops happen when the condition never becomes False. They usually mean a missing update to the loop variable or a logic error in the condition.
+
+break exits the nearest loop immediately. continue skips the rest of the current iteration and moves to the next one. Both are useful sparingly; overusing them can hide the main loop logic.

--- a/backend/evals/corpus/smoke_oop.txt
+++ b/backend/evals/corpus/smoke_oop.txt
@@ -1,0 +1,7 @@
+Object-oriented programming organizes code around objects that combine state and behavior. A class is a blueprint; an instance is a concrete object created from that class.
+
+Methods are functions defined on a class. The first parameter is usually named self and refers to the instance. Attributes store per-instance data such as a balance or a name.
+
+Encapsulation means hiding internal details behind a clear interface. Inheritance lets a subclass reuse and extend a parent class. Polymorphism lets callers use objects through a shared interface without knowing the concrete type.
+
+Prefer composition (has-a) when inheritance (is-a) feels forced. Deep inheritance hierarchies are a common source of brittle design.

--- a/backend/evals/corpus/smoke_stacks_queues.txt
+++ b/backend/evals/corpus/smoke_stacks_queues.txt
@@ -1,0 +1,7 @@
+A stack is a last-in, first-out (LIFO) structure. Push adds an item; pop removes the most recently added item. Call stacks in programming languages are a classic example.
+
+A queue is first-in, first-out (FIFO). Enqueue adds at the back; dequeue removes from the front. Print spoolers and breadth-first search use queues.
+
+In Python, a list can act as a stack with append and pop. For queues, collections.deque is preferred because popping from the left of a list is O(n).
+
+Choosing the wrong structure often shows up as awkward code: scanning an entire list to remove the oldest item is a sign you wanted a queue.

--- a/backend/evals/corpus/smoke_testing.txt
+++ b/backend/evals/corpus/smoke_testing.txt
@@ -1,0 +1,7 @@
+Testing checks that code behaves as intended. A unit test focuses on a small piece in isolation, usually a function or method.
+
+A good test has a clear arrange/act/assert structure: set up inputs, call the code, and check the result. Assertions fail the test when the actual value differs from the expected value.
+
+Regression tests catch bugs that return after a fix. Edge cases (empty input, zero, negatives, duplicates) often reveal mistakes that happy-path tests miss.
+
+Automated tests should be fast and deterministic. Tests that depend on the network, the current time, or random values without control become flaky and lose trust.

--- a/backend/evals/corpus/smoke_variables.txt
+++ b/backend/evals/corpus/smoke_variables.txt
@@ -1,0 +1,7 @@
+Variables store values that a program can use and update. In Python, you create a variable by assigning with =, for example x = 3.
+
+Python is dynamically typed: the same name can later hold a different type. Types still matter. Common built-in types include int, float, str, and bool.
+
+Names should describe what the value means. Avoid single-letter names except for short loop indices. Constants that should not change are often written in ALL_CAPS by convention, even though Python does not enforce immutability.
+
+An expression produces a value. A statement performs an action, such as an assignment or a print call. Understanding the difference helps when reading error messages and debugging.

--- a/backend/evals/rubric.md
+++ b/backend/evals/rubric.md
@@ -22,3 +22,24 @@ Score each **five-question set as a whole** (not each question). Scale **1–5**
 - **Reliability:** success rate, schema validity — did generation work?
 - **Correctness gates:** answer-in-options, MC/TF counts — contract compliance
 - **Efficiency:** latency / tokens — cost tradeoffs, not quality
+
+## Manual scores — smoke run `2026-07-31T00-10-58Z` (1 doc: `smoke_recursion`)
+
+Scored from saved artifacts (not a live re-run). Auto gates from that run: A 100% / B 60% / C 80% answer-in-options.
+
+| Criterion | A (baseline) | B (difficulty) | C (distractors) |
+|-----------|--------------|----------------|-----------------|
+| Appropriate difficulty | 3 | 4 | 3 |
+| Clear wording | 4 | 2 | 4 |
+| Good distractors | 3 | 3 | 4 |
+| Grounded in lecture | 5 | 4 | 5 |
+| **Overall** | **4** | **2** | **3** |
+
+Notes:
+- **A:** Contract-clean; questions are grounded and usable. Some MC options are soft/near-tautological.
+- **B:** Intended harder items, but two T/F rows used sentence answers (`"A base case"`, long memory phrase) instead of `True`/`False` → ungradable. Overall capped by correctness failure.
+- **C:** Stronger distractors on MC; one MC failed exact answer∈options because the answer string had a trailing period the option lacked.
+
+### Takeaway (ship / no-ship)
+
+**Ship prompt A.** It alone passed correctness gates and produced exam-usable grounded questions. Hold B/C until the answer∈options validator is merged and a re-smoke shows 100% contract compliance (or clean validation failures with nothing persisted).

--- a/backend/tests/core/test_openai.py
+++ b/backend/tests/core/test_openai.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 import pytest
 from fastapi import HTTPException
+from pydantic import ValidationError
 
 from app.core.ai.openai import (
     MAX_CHARS,
@@ -123,6 +124,18 @@ def test_validate_and_convert_question_item_true_false() -> None:
     assert result.options == ["True", "False"]
 
 
+def test_validate_and_convert_question_item_rejects_answer_not_in_options() -> None:
+    """Bad T/F answers must raise ValidationError (generation maps to error_kind=validation)."""
+    mock_question = MagicMock()
+    mock_question.question = "Every recursive function needs a base case."
+    mock_question.answer = "A base case"
+    mock_question.type = "true_false"
+    mock_question.options = ["True", "False"]
+
+    with pytest.raises(ValidationError):
+        validate_and_convert_question_item(mock_question)
+
+
 def test_parse_llm_output_success() -> None:
     """Test parsing LLM output successfully."""
     mock_question1 = MagicMock()
@@ -177,6 +190,34 @@ def test_parse_llm_output_filters_none() -> None:
         result = parse_llm_output(mock_llm_output)
 
     assert result == []
+
+
+@pytest.mark.asyncio
+async def test_generate_questions_maps_answer_not_in_options_to_validation() -> None:
+    """Invalid answer∉options during parse must fail with error_kind=validation."""
+    from app.core.ai.openai import generate_questions
+
+    mock_llm = MagicMock()
+    mock_parsed = MagicMock()
+    bad_q = MagicMock()
+    bad_q.question = "Every recursive function needs a base case."
+    bad_q.answer = "A base case"
+    bad_q.type = "true_false"
+    bad_q.options = ["True", "False"]
+    mock_parsed.questions = [bad_q]
+    mock_llm.ainvoke = AsyncMock(
+        return_value={"parsed": mock_parsed, "raw": None, "parsing_error": None}
+    )
+
+    with patch("app.core.ai.openai._question_llm", return_value=mock_llm):
+        result = await generate_questions(
+            "lecture text", prompt_id="a", num_questions=1
+        )
+
+    assert result.ok is False
+    assert result.error_kind == "validation"
+    assert result.questions == []
+    assert result.schema_valid is False
 
 
 @pytest.mark.asyncio

--- a/backend/tests/models/test_question_item.py
+++ b/backend/tests/models/test_question_item.py
@@ -1,0 +1,74 @@
+"""Unit tests for QuestionItem answer ∈ options validation."""
+
+import pytest
+from pydantic import ValidationError
+
+from app.models import QuestionItem
+
+
+def test_question_item_valid_multiple_choice() -> None:
+    item = QuestionItem(
+        question="What is 2+2?",
+        answer="4",
+        type="multiple_choice",
+        options=["2", "3", "4", "5"],
+    )
+    assert item.type == "multiple_choice"
+    assert item.answer == "4"
+    assert item.options == ["2", "3", "4", "5"]
+
+
+def test_question_item_valid_true_false() -> None:
+    item = QuestionItem(
+        question="Is the sky blue?",
+        answer="True",
+        type="true_false",
+        options=["True", "False"],
+    )
+    assert item.type == "true_false"
+    assert item.answer == "True"
+    assert item.options == ["True", "False"]
+
+
+def test_question_item_true_false_normalizes_answer_case() -> None:
+    item = QuestionItem(
+        question="Recursion needs a base case.",
+        answer="true",
+        type="true_false",
+        options=["true", "false"],
+    )
+    assert item.answer == "True"
+    assert item.options == ["True", "False"]
+
+
+def test_question_item_rejects_true_false_answer_not_in_options() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        QuestionItem(
+            question="Every recursive function needs a base case.",
+            answer="A base case",
+            type="true_false",
+            options=["True", "False"],
+        )
+    assert "True/false answer must be one of" in str(exc_info.value)
+
+
+def test_question_item_rejects_multiple_choice_answer_not_in_options() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        QuestionItem(
+            question="What is 2+2?",
+            answer="6",
+            type="multiple_choice",
+            options=["2", "3", "4", "5"],
+        )
+    assert "Answer must be one of the options" in str(exc_info.value)
+
+
+def test_question_item_rejects_missing_answer() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        QuestionItem(
+            question="What is 2+2?",
+            answer=None,
+            type="multiple_choice",
+            options=["2", "3", "4", "5"],
+        )
+    assert "answer is required" in str(exc_info.value)


### PR DESCRIPTION
## Summary
- Enforce `answer ∈ options` on `QuestionItem` (with T/F answer normalization to `True`/`False`) so invalid structured output cannot persist.
- Re-validate via `QuestionItem` in `validate_and_convert_question_item` so the generation path fails with `error_kind=validation` instead of shipping ungradable T/F/MC items.
- Add unit tests for valid MC/T/F, invalid answer-not-in-options cases, and generation mapping to `error_kind=validation`.

## Test plan
- [x] `pytest tests/models/test_question_item.py` + related `test_openai` cases (`--noconftest`; local DB/docker was down)
- [ ] CI backend tests on this PR
- [ ] Re-smoke: `cd backend && python scripts/evaluate.py --prompts a,b,c --limit 1` and confirm mean answer-in-options is 100% (or failures are validation, not persisted bad answers)
